### PR TITLE
Fix package-lint/check-doc/byte-compiler warnings

### DIFF
--- a/ameba.el
+++ b/ameba.el
@@ -1,4 +1,4 @@
-;;; ameba.el --- An interface to Crystal Ameba linter. -*- lexical-binding: t; -*-
+;;; ameba.el --- An interface to Crystal Ameba linter  -*- lexical-binding: t; -*-
 
 ;; Copyright © 2018-2019 Vitalii Elenhaupt <velenhaupt@gmail.com>
 ;; Author: Vitalii Elenhaupt

--- a/flycheck-ameba.el
+++ b/flycheck-ameba.el
@@ -71,9 +71,7 @@ This is either a parent directory containing a .ameba.yml, or nil."
         (point (concat filename ":" line ":" column)))
       (with-output-to-string
         (call-process "ameba" nil standard-output nil "--explain" point "--no-color"))))
-
-  :modes crystal-mode
-  )
+  :modes crystal-mode)
 
 ;;;###autoload
 (defun flycheck-ameba-setup ()

--- a/flycheck-ameba.el
+++ b/flycheck-ameba.el
@@ -39,10 +39,10 @@
   "Compute an appropriate working-directory for flycheck-ameba.
 This is either a parent directory containing a .ameba.yml, or nil."
   (or
-  (and
+   (and
     buffer-file-name
     (locate-dominating-file buffer-file-name ".ameba.yml"))
-  default-directory))
+   default-directory))
 
 (flycheck-define-checker crystal-ameba
   "A Crystal static syntax checker using ameba linter"
@@ -65,10 +65,10 @@ This is either a parent directory containing a .ameba.yml, or nil."
   :error-explainer
   (lambda (error)
     (let*
-       ((filename (flycheck-error-filename error))
-        (line (number-to-string (flycheck-error-line error)))
-        (column (number-to-string (flycheck-error-column error)))
-        (point (concat filename ":" line ":" column)))
+        ((filename (flycheck-error-filename error))
+         (line (number-to-string (flycheck-error-line error)))
+         (column (number-to-string (flycheck-error-column error)))
+         (point (concat filename ":" line ":" column)))
       (with-output-to-string
         (call-process "ameba" nil standard-output nil "--explain" point "--no-color"))))
   :modes crystal-mode)


### PR DESCRIPTION
Hi!
I found this package and I fix flycheck warnings for my first contribution step!

### before

``` emacs-lisp
 ameba.el     1   1 warning         The package summary should not end with a period. (emacs-lisp-package)
 flycheck…    76   3 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
```

### after

No errors!